### PR TITLE
Update vega-expression to retrieve it from the elastic pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vega-parser",
-  "version": "2.5.0",
+  "name": "@elastic/vega-parser",
+  "version": "2.5.0-kibana",
   "description": "Parse Vega specifications to runtime dataflows.",
   "keywords": [
     "vega",
@@ -37,7 +37,7 @@
     "d3-time-format": "2",
     "vega-dataflow": "3",
     "vega-event-selector": "2",
-    "vega-expression": "2",
+    "vega-expression": "npm:@elastic/vega-expression@2.4.0-kibana",
     "vega-scale": "2",
     "vega-scenegraph": "2",
     "vega-statistics": "^1.2",

--- a/test/signal-test.js
+++ b/test/signal-test.js
@@ -60,7 +60,7 @@ tape('Parser parses signals with event-driven updates', function(test) {
           {source: 'window', type: 'touchstart'},
           {signal: 'a'}
         ],
-        update: {expr: '2*2'},
+        update: {expr: '2 * 2'},
         force: false
       }
     ]
@@ -99,13 +99,13 @@ tape('Parser parses signals with event-driven updates', function(test) {
   update = scope.updates[1];
   test.equal(update.source, a);
   test.equal(update.target, c);
-  test.equal(update.update.$expr, 'var datum=event.item&&event.item.datum;return((2*2));');
+  test.equal(update.update.$expr, 'var datum=event.item&&event.item.datum;return((2 * 2));');
   test.equal(update.options, undefined);
 
   update = scope.updates[2];
   test.equal(update.source, 5);
   test.equal(update.target, c);
-  test.equal(update.update.$expr, 'var datum=event.item&&event.item.datum;return((2*2));');
+  test.equal(update.update.$expr, 'var datum=event.item&&event.item.datum;return((2 * 2));');
   test.equal(update.options, undefined);
 
   update = scope.updates[3];

--- a/test/stream-test.js
+++ b/test/stream-test.js
@@ -86,7 +86,7 @@ tape('Parser parses stream definitions', function(test) {
   test.deepEqual(scope.streams[3], {
     id: view,
     stream: 3,
-    filter: "(event.shiftKey&&((event.item&&(event.item.mark.marktype==='rect'))&&(event.item.mark.name==='foo')))",
+    filter: "(event.shiftKey&&((event.item&&(event.item.mark.marktype === 'rect'))&&(event.item.mark.name === 'foo')))",
     throttle: 3,
     debounce: 4
   });

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -47,7 +47,7 @@ tape('Parser parses Vega specs with data transforms', function(test) {
 
   var dfs = parse(spec);
 
-  test.equal(dfs.operators.length, 33);
+  test.equal(dfs.operators.length, 31);
 
   test.end();
 });


### PR DESCRIPTION
We need to update both vega-parser and vega-lib with the @elastic/vega-expression package. 
vega-lib used on kibana 6.8 is on version 3.3.1 and it uses ~~vega-parser 2.5~~. vega-parser 2.7 

A note here: Vega-parser 2.5 uses the vega-expression 2. I upgraded it to 2.4.0. I saw the changelog and the changes are mainly bug fixes so I don't think that it will cause any problem.